### PR TITLE
Fix bug when multiple windows

### DIFF
--- a/ext/src/browser_action/lol.js
+++ b/ext/src/browser_action/lol.js
@@ -67,7 +67,7 @@ fetch(dataSourceUrl)
   .then((response) => response.json())
   .then(createAlternativeSearch)
   .then(getAlternatives => {
-    chrome.tabs.query({ active: true }, (tabs) => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       const currentUrl = tabs[0].url;
       const alternatives = getAlternatives(currentUrl);
       let html;


### PR DESCRIPTION
## Steps to reproduce

* open 2 Chrome windows
* and on the 2nd window, attempt to use the extension
* notice it shows the results from the original window


## Caveats

We originally had this `currentWindow: true` when we first hacked this together but removed it for a reason I can't remember.
